### PR TITLE
Update debian usage (inserting the package name gave an error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Currently supports generating PKGBUILDs for Ruby Gems, NodeJS and Python package
 ```
 USAGE:
  * ./pkgbake python package_name
- * ./pkgbake debian package_name
  * ./pkgbake nodejs package_name
  * ./pkgbake ruby package_name
+ * ./pkgbake debian url_to_deb_file
 ```
 
 ## DEPENDENCIES


### PR DESCRIPTION
I'm not sure if this was intended or this was a minor typo.

I've created this pull request but if it was intended to have package_name as a future feature, never mind this request.
